### PR TITLE
feat: add release helper scripts with --push flag

### DIFF
--- a/release.ps1
+++ b/release.ps1
@@ -1,0 +1,44 @@
+# Usage: .\release.ps1 [-Bump patch|minor|major] [-Push]
+# Bumps the npm version in package.json, creates a git commit, and tags it.
+# With -Push, also pushes the commit and tag to origin.
+param(
+    [ValidateSet("patch", "minor", "major")]
+    [string]$Bump = "patch",
+    [switch]$Push
+)
+
+$ErrorActionPreference = "Stop"
+
+# Ensure we are at the repo root (where this script lives)
+Set-Location $PSScriptRoot
+
+# Check for uncommitted changes before doing anything
+$status = git status --porcelain
+if ($status) {
+    Write-Error "Working tree has uncommitted changes. Commit or stash them first."
+    exit 1
+}
+
+# Bump version in package.json only (--no-git-tag-version skips git operations)
+npm version $Bump --no-git-tag-version
+
+# Read the new version
+$Version = node -e "console.log(require('./package.json').version)"
+$Tag = "v$Version"
+
+Write-Host "Releasing $Tag..."
+
+git add package.json package-lock.json
+git commit -m "chore: release $Tag"
+git tag $Tag
+
+if ($Push) {
+    Write-Host "Pushing $Tag..."
+    git push
+    git push --tags
+} else {
+    Write-Host ""
+    Write-Host "Done. Run the following to publish:"
+    Write-Host ""
+    Write-Host "  git push; git push --tags"
+}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Usage: ./release.sh [patch|minor|major] [--push|-p]
+# Bumps the npm version in package.json, creates a git commit, and tags it.
+# With --push (or -p), also pushes the commit and tag to origin.
+set -euo pipefail
+
+BUMP="patch"
+PUSH=false
+
+for arg in "$@"; do
+  case "$arg" in
+    patch|minor|major) BUMP="$arg" ;;
+    --push|-p)         PUSH=true ;;
+    *)
+      echo "Usage: ./release.sh [patch|minor|major] [--push|-p]"
+      echo ""
+      echo "  patch  (default) — bug fix:           v1.2.3 → v1.2.4"
+      echo "  minor            — new feature:        v1.2.3 → v1.3.0"
+      echo "  major            — breaking change:    v1.2.3 → v2.0.0"
+      echo "  --push, -p       — also run: git push && git push --tags"
+      exit 1
+      ;;
+  esac
+done
+
+# Ensure we are at the repo root (where this script lives)
+cd "$(dirname "$0")"
+
+# Check for uncommitted changes before doing anything
+# (git status --porcelain also catches untracked files)
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: working tree has uncommitted changes. Commit or stash them first."
+  exit 1
+fi
+
+# Bump version in package.json only (--no-git-tag-version skips git operations)
+npm version "$BUMP" --no-git-tag-version
+
+# Read the new version
+VERSION=$(node -e "console.log(require('./package.json').version)")
+TAG="v${VERSION}"
+
+echo "Releasing ${TAG}..."
+
+git add package.json package-lock.json
+git commit -m "chore: release ${TAG}"
+git tag "${TAG}"
+
+if $PUSH; then
+  echo "Pushing ${TAG}..."
+  git push
+  git push --tags
+else
+  echo ""
+  echo "Done. Run the following to publish:"
+  echo ""
+  echo "  git push && git push --tags"
+fi


### PR DESCRIPTION
## Summary

Ports the release helper scripts from anime-list-next (`release.sh` / `release.ps1`) to this repo and adds a new **`--push` / `-p`** flag.

## What the script does

```
./release.sh [patch|minor|major] [--push|-p]
```

1. Bumps the npm version in the root `package.json` (`--no-git-tag-version`)
2. Commits `chore: release vX.Y.Z`
3. Tags `vX.Y.Z`
4. With `--push`/`-p`: also runs `git push && git push --tags` (pushing the tag triggers the v* docker workflow from #12)

PowerShell equivalent: `.\release.ps1 [-Bump patch|minor|major] [-Push]`

## Differences from anime-list-next

- Version is in the **root** `package.json` (not `client/`)
- Dirty-tree guard uses `git status --porcelain` so **untracked files also block the release** (the original bash guard only checked tracked diffs; the PS version already used `--porcelain`)

## Verified

- Default `patch` bump: commit + tag created, no push, prints push instructions
- `--push` / flag-only (`./release.sh --push`): commit + tag pushed to remote
- `minor` bump + `--push`: v0.1.0 pushed correctly
- Guard: tracked modification **and** untracked file both block with exit 1
- Invalid bump arg: usage error, exit 1

All tested end-to-end against a local bare remote (no GitHub side effects).

## Usage

```sh
./release.sh patch --push   # bump, commit, tag, push (triggers CI release)
```